### PR TITLE
Fix bugs as requested by Kella

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -14,6 +14,11 @@ label {
 
 input {
   display: block;
+
+  &[type="text"],
+  &[type="url"] {
+    width: 100%;
+  }
 }
 
 select {

--- a/src/html/index.pug
+++ b/src/html/index.pug
@@ -16,7 +16,6 @@ html(lang="en-us")
         +inputText('title')(spellcheck="true") Event Title
         +inputDate('date') Event Date
         +inputText('cost') Cost
-        +inputUrl('facebookEventUrl') Facebook event URL
         +inputTextarea('intro')(spellcheck="true") Organizer's intro
         +inputText('dj') DJ
         +inputSelect('musicType', 'musicTypeOptions') Music type
@@ -35,6 +34,7 @@ html(lang="en-us")
             data-bind="click: addUpcomingEvent"
             type="button"
           ) Add upcoming event
+        +inputUrl('facebookEventUrl') Facebook event URL
     section
       h2 Copy the results below
 

--- a/src/html/index.pug
+++ b/src/html/index.pug
@@ -39,6 +39,7 @@ html(lang="en-us")
       h2 Copy the results below
 
       h3 Facebook Event
+      +outputTextLine('title')
       +outputText('facebook')
 
       h3 etango email

--- a/src/html/mixins/output.pug
+++ b/src/html/mixins/output.pug
@@ -5,6 +5,14 @@ mixin outputText(koPropName)
     spellcheck="false"
   )&attributes(attributes)
 
+mixin outputTextLine(koPropName)
+  input(
+    data-bind=`value: ${koPropName}`
+    type="text"
+    readonly
+    spellcheck="false"
+  )&attributes(attributes)
+
 mixin outputHtml(koPropName)
   div(
     data-bind=`html: ${koPropName}`

--- a/src/templates/facebook.ejs.txt
+++ b/src/templates/facebook.ejs.txt
@@ -27,6 +27,7 @@ Accessibility: The Vet’s club’s ramp is on the front-right corner of the bui
 
 —————————
 Upcoming Events:
+
 <%_ for (const event of locals.upcomingEvents) { _%>
 	• <%- event.date %> - <%- event.title %>
 <%_ } _%>

--- a/src/templates/facebook.ejs.txt
+++ b/src/templates/facebook.ejs.txt
@@ -1,24 +1,24 @@
 <%_ if (locals.intro !== '') { _%>
-<%= locals.intro %>
+<%- locals.intro %>
 
 <%_ } _%>
 This Week’s Event
 
-Tuesday, <%= locals.date %>
+Tuesday, <%- locals.date %>
 
 Schedule:
 	• 7:00PM - Beginning and Intermediate lessons
-	• 7:45–10PM - DJ <%= locals.dj %>
+	• 7:45–10PM - DJ <%- locals.dj %>
 
-Intermediate teacher: <%= locals.teacherIntermediate %>
-Lesson topic: <%= locals.topicIntermediate %>
-Beginner teacher: <%= locals.teacherBeginner %>
-Lesson topic: <%= locals.topicBeginner %>
+Intermediate teacher: <%- locals.teacherIntermediate %>
+Lesson topic: <%- locals.topicIntermediate %>
+Beginner teacher: <%- locals.teacherBeginner %>
+Lesson topic: <%- locals.topicBeginner %>
 
-DJ: <%= locals.dj %>
-Music: <%= locals.musicType %>
+DJ: <%- locals.dj %>
+Music: <%- locals.musicType %>
 
-Cost: <%= locals.cost %> (Cash or check only)
+Cost: <%- locals.cost %> (Cash or check only)
 Volunteer: 30-minute desk shift gets you in free!
 
 Parking: To the left of Vet’s club building or nearby street parking
@@ -28,6 +28,6 @@ Accessibility: The Vet’s club’s ramp is on the front-right corner of the bui
 —————————
 Upcoming Events:
 <%_ for (const event of locals.upcomingEvents) { _%>
-	• <%= event.date %> - <%= event.title %>
+	• <%- event.date %> - <%- event.title %>
 <%_ } _%>
 <%_ } _%>


### PR DESCRIPTION
* Don't HTML escape fields in Facebook template
* Add a blank line after "Upcoming Events" for FB
* Move the Facebook URL input field to the bottom
* Add an output field for Event Title to FB section
* Stretch all text input fields to full width